### PR TITLE
Fixed broken github.com update sites

### DIFF
--- a/com.vogella.vde.luna.product/com.vogella.vde.luna.p2.inf
+++ b/com.vogella.vde.luna.product/com.vogella.vde.luna.p2.inf
@@ -1,3 +1,3 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//raw2.github.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite,name: Voclipse Composit Updatesite);\
-addRepository(type:1,location:https${#58}//raw2.github.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite,name: Voclipse Composit Updatesite);;
+addRepository(type:0,location:https${#58}//raw.githubusercontent.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite,name: Voclipse Composit Updatesite);\
+addRepository(type:1,location:https${#58}//raw.githubusercontent.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite,name: Voclipse Composit Updatesite);;

--- a/com.vogella.vde.parent/pom.xml
+++ b/com.vogella.vde.parent/pom.xml
@@ -24,7 +24,7 @@
 
 		<repository>
 			<id>voclipse-composit-updatesite</id>
-			<url>https://raw2.github.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite/</url>
+			<url>https://raw.githubusercontent.com/vogellacompany/com.vogella.vde/master/com.vogella.vde.luna.updatesite/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>


### PR DESCRIPTION
The build currently fails https://build.vogella.com/ci/job/C-MASTER-com.vogella.vde.luna/lastFailedBuild/console :( Apparently URLs changed https://developer.github.com/changes/2014-04-25-user-content-security/ I hope this fixes the problem.
