### PR TITLE
Update Eclipse Tycho plugin to 0.21.0

### DIFF
--- a/com.vogella.vde.parent/pom.xml
+++ b/com.vogella.vde.parent/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>0.20.0-SNAPSHOT</tycho-version>
+		<tycho-version>0.21.0-SNAPSHOT</tycho-version>
 	</properties>
 
 	<pluginRepositories>


### PR DESCRIPTION
This won't fix the build. I just found out that a new version is available at https://oss.sonatype.org/content/groups/public/org/eclipse/tycho/tycho-maven-plugin/ when trying to investigate the problem.
